### PR TITLE
README: Fix missing quotation in codeblock

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install @comandeer/rollup-plugin-macros --save-dev
 Add it to your Rollup.js configuration:
 
 ```javascript
-import macros from '@comandeer/rollup-plugin-macros;
+import macros from '@comandeer/rollup-plugin-macros';
 
 export default {
     input: './src/index.js',


### PR DESCRIPTION
It was bugging me :-)

P.S. Great work!  I'm not sure why macros are so unexplored in Rollup, or bundling in general -- simple "replace"-type plugins aren't as cool or functional as this thing.